### PR TITLE
[Doc] Fix missing support for unstable feature `doc(cfg)`

### DIFF
--- a/crates/valust-axum/src/lib.rs
+++ b/crates/valust-axum/src/lib.rs
@@ -1,3 +1,4 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod extractor;


### PR DESCRIPTION
- Add crate-level attr to support `doc(cfg)`.  
  Closes #16.