### PR TITLE
[Doc] Add link to `valust-axum` crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ assert_eq!(profile, UserProfile {
 ### External Tools & Utilities
 
 - [`valust-utils`](https://crates.io/crates/valust-utils): Utilities that might be used when defining validators.
+- [`valust-axum`](https://crates.io/crates/valust-axum): Utilities for integrating `valust` with [`axum`](https://crates.io/crates/axum).
 
 ## Minimum Supported Rust Version (MSRV)
 

--- a/src/valust/README.md
+++ b/src/valust/README.md
@@ -56,6 +56,7 @@ assert_eq!(profile, UserProfile {
 ### External Tools & Utilities
 
 - [`valust-utils`](https://crates.io/crates/valust-utils): Utilities that might be used when defining validators.
+- [`valust-axum`](https://crates.io/crates/valust-axum): Utilities for integrating `valust` with [`axum`](https://crates.io/crates/axum).
 
 ## Minimum Supported Rust Version (MSRV)
 


### PR DESCRIPTION
- Add link to `valust-axum` crate in the README file.  
  Closes #17.