### PR TITLE
[Feat] Add utils for regex validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,6 +1079,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "valust-regex-utils"
+version = "0.4.0"
+
+[[package]]
 name = "valust-utils"
 version = "0.4.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1081,6 +1081,9 @@ dependencies = [
 [[package]]
 name = "valust-regex-utils"
 version = "0.4.0"
+dependencies = [
+ "regex",
+]
 
 [[package]]
 name = "valust-utils"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "tests",
     "crates/valust-utils",
     "crates/valust-axum",
+    "crates/valust-regex-utils",
 ]
 resolver = "2"
 

--- a/crates/valust-regex-utils/Cargo.toml
+++ b/crates/valust-regex-utils/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "valust-regex-utils"
+keywords = ["validator", "data", "regex", "utils"]
+description = "Regex utilities for the Valust crate"
+
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+categories.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/valust-regex-utils/Cargo.toml
+++ b/crates/valust-regex-utils/Cargo.toml
@@ -12,5 +12,8 @@ categories.workspace = true
 
 [dependencies]
 
+[dev-dependencies]
+regex = { version = "1.11.1" }
+
 [lints]
 workspace = true

--- a/crates/valust-regex-utils/README.md
+++ b/crates/valust-regex-utils/README.md
@@ -1,0 +1,17 @@
+# Regex Utilities for Valust
+
+<center>
+
+<img alt="Crate Version" src="https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fgithub.com%2FEmbers-of-the-Fire%2Fvalust-rs%2Fraw%2Frefs%2Fheads%2Fmain%2FCargo.toml&query=%24.workspace.package.version&prefix=v%20&style=for-the-badge&label=version">&emsp;
+<img alt="GitHub top language" src="https://img.shields.io/github/languages/top/embers-of-the-fire/valust-rs?style=for-the-badge&color=%23FF9B07">&emsp;
+<a href="https://crates.io/crates/valust-regex-utils">
+    <img alt="Crates.io Downloads (recent)" src="https://img.shields.io/crates/dr/valust-regex-utils?style=for-the-badge">
+</a>
+
+</center>
+
+---
+
+This crates exports some regex expressions that might be used.
+
+For more information, see the crate's documentation for more information.

--- a/crates/valust-regex-utils/src/lib.rs
+++ b/crates/valust-regex-utils/src/lib.rs
@@ -1,56 +1,68 @@
 #![doc = include_str!("../README.md")]
 
+pub mod time;
+
 /// Regex for matching a valid email address.
+///
+/// ## Example
+///
+/// ```rust
+/// use regex::Regex;
+/// use valust_regex_utils::EMAIL;
+///
+/// let email_regex = Regex::new(EMAIL).unwrap();
+/// assert!(email_regex.is_match("hello@world.com"));
+/// ```
 ///
 /// ## Reference
 ///
 /// - [HTML Standard / Email Address](https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address)
-pub const EMAIL: &str = r"^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$";
-
-/// Regex for URL validation.
-/// 
-/// ## Reference
-/// 
-/// - [URL regex pattern by Diego Perini](https://gist.github.com/dperini/729294)
-#[rustfmt::skip]
-pub const URL: &str = concat!(
-    "^",
-        // protocol identifier (optional)
-        // short syntax // still required
-        "(?:(?:(?:https?|ftp):)?\\/\\/)",
-        // user:pass BasicAuth (optional)
-        "(?:\\S+(?::\\S*)?@)?",
-        "(?:",
-            // IP address exclusion
-            // private & local networks
-            "(?!(?:10|127)(?:\\.\\d{1,3}){3})",
-            "(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})",
-            "(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})",
-            // IP address dotted notation octets
-            // excludes loopback network 0.0.0.0
-            // excludes reserved space >= 224.0.0.0
-            // excludes network & broadcast addresses
-            // (first & last IP address of each class)
-            "(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])",
-            "(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}",
-            "(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))",
-        "|",
-            // host & domain names, may end with dot
-            // can be replaced by a shortest alternative
-            // (?![-_])(?:[-\\w\\u00a1-\\uffff]{0,63}[^-_]\\.)+
-            "(?:",
-                "(?:",
-                    "[a-z0-9\\u00a1-\\uffff]",
-                    "[a-z0-9\\u00a1-\\uffff_-]{0,62}",
-                ")?",
-                "[a-z0-9\\u00a1-\\uffff]\\.",
-            ")+",
-            // TLD identifier name, may end with dot
-            "(?:[a-z\\u00a1-\\uffff]{2,}\\.?)",
-        ")",
-        // port number (optional)
-        "(?::\\d{2,5})?",
-        // resource path (optional)
-        "(?:[/?#]\\S*)?",
-    "$",
+pub const EMAIL: &str = concat!(
+    r"^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+",
+    r"@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
 );
+
+/// Regex for matching a syntax-valid URL.
+///
+/// This regex does not check if the URL is reachable, e.g., if the IP address is valid.
+///
+/// ## Example
+///
+/// ```rust
+/// use regex::Regex;
+/// use valust_regex_utils::URL;
+///
+/// let url_regex = Regex::new(URL).unwrap();
+/// assert!(url_regex.is_match("https://www.google.com"));
+/// ```
+pub const URL: &str = r"^(https?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)$";
+
+/// Regex for matching a valid ascii username with a minimum length of 3 characters.
+///
+/// ## Example
+///
+/// ```rust
+/// use regex::Regex;
+/// use valust_regex_utils::USERNAME;
+///
+/// let username_regex = Regex::new(USERNAME).unwrap();
+/// assert!(username_regex.is_match("hello-world"));
+/// assert!(!username_regex.is_match("hi"));
+/// ```
+pub const USERNAME: &str = r"^[a-zA-Z0-9_-]{3,}$";
+
+/// Regex for matching a valid hex color (`#aabbcc`/`#abc`).
+///
+/// ## Example
+///
+/// ```rust
+/// use regex::Regex;
+/// use valust_regex_utils::HEX_COLOR;
+///
+/// let color_regex = Regex::new(HEX_COLOR).unwrap();
+/// assert!(color_regex.is_match("#00ff00"));
+/// assert!(color_regex.is_match("#123"));
+/// assert!(color_regex.is_match("#223344ff"));
+/// ```
+pub const HEX_COLOR: &str =
+    r"^#?([a-fA-F0-9]{8}|[a-fA-F0-9]{6}|[a-fA-F0-9]{4}|[a-fA-F0-9]{3})$";

--- a/crates/valust-regex-utils/src/lib.rs
+++ b/crates/valust-regex-utils/src/lib.rs
@@ -1,0 +1,56 @@
+#![doc = include_str!("../README.md")]
+
+/// Regex for matching a valid email address.
+///
+/// ## Reference
+///
+/// - [HTML Standard / Email Address](https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address)
+pub const EMAIL: &str = r"^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$";
+
+/// Regex for URL validation.
+/// 
+/// ## Reference
+/// 
+/// - [URL regex pattern by Diego Perini](https://gist.github.com/dperini/729294)
+#[rustfmt::skip]
+pub const URL: &str = concat!(
+    "^",
+        // protocol identifier (optional)
+        // short syntax // still required
+        "(?:(?:(?:https?|ftp):)?\\/\\/)",
+        // user:pass BasicAuth (optional)
+        "(?:\\S+(?::\\S*)?@)?",
+        "(?:",
+            // IP address exclusion
+            // private & local networks
+            "(?!(?:10|127)(?:\\.\\d{1,3}){3})",
+            "(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})",
+            "(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})",
+            // IP address dotted notation octets
+            // excludes loopback network 0.0.0.0
+            // excludes reserved space >= 224.0.0.0
+            // excludes network & broadcast addresses
+            // (first & last IP address of each class)
+            "(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])",
+            "(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}",
+            "(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))",
+        "|",
+            // host & domain names, may end with dot
+            // can be replaced by a shortest alternative
+            // (?![-_])(?:[-\\w\\u00a1-\\uffff]{0,63}[^-_]\\.)+
+            "(?:",
+                "(?:",
+                    "[a-z0-9\\u00a1-\\uffff]",
+                    "[a-z0-9\\u00a1-\\uffff_-]{0,62}",
+                ")?",
+                "[a-z0-9\\u00a1-\\uffff]\\.",
+            ")+",
+            // TLD identifier name, may end with dot
+            "(?:[a-z\\u00a1-\\uffff]{2,}\\.?)",
+        ")",
+        // port number (optional)
+        "(?::\\d{2,5})?",
+        // resource path (optional)
+        "(?:[/?#]\\S*)?",
+    "$",
+);

--- a/crates/valust-regex-utils/src/time.rs
+++ b/crates/valust-regex-utils/src/time.rs
@@ -1,0 +1,106 @@
+//! Time-related regex expressions.
+
+/// Regex for matching a valid 12-hour time format (HH:MM) with no `am/pm` suffix.
+///
+/// Note this regex allows omitting the leading zeros.
+///
+/// ## Example
+///
+/// ```rust
+/// use regex::Regex;
+/// use valust_regex_utils::time::HH_MM_12H_NO_LEADING_NO_SUFFIX;
+///
+/// let time_regex = Regex::new(HH_MM_12H_NO_LEADING_NO_SUFFIX).unwrap();
+/// assert!(time_regex.is_match("1:00"));
+/// assert!(time_regex.is_match("12:00"));
+/// assert!(!time_regex.is_match("13:00"));
+///
+/// assert!(time_regex.is_match("1:59"));
+/// assert!(!time_regex.is_match("1:60"));
+/// ```
+pub const HH_MM_12H_NO_LEADING_NO_SUFFIX: &str = r"^(0?[1-9]|1[0-2]):[0-5][0-9]$";
+
+/// Regex for matching a valid 12-hour time format (HH:MM) with `am/pm` suffix.
+///
+/// Note this regex allows omitting the leading zeros.
+///
+/// ## Example
+///
+/// ```rust
+/// use regex::Regex;
+/// use valust_regex_utils::time::HH_MM_12H_NO_LEADING;
+///
+/// let time_regex = Regex::new(HH_MM_12H_NO_LEADING).unwrap();
+///
+/// assert!(time_regex.is_match("1:00 am"));
+/// assert!(time_regex.is_match("12:00 pm"));
+/// assert!(!time_regex.is_match("13:00 am"));
+///
+/// assert!(time_regex.is_match("1:59 pm"));
+/// assert!(!time_regex.is_match("1:60 am"));
+/// ```
+pub const HH_MM_12H_NO_LEADING: &str =
+    r"^((1[0-2]|0?[1-9]):([0-5][0-9]) ?([AaPp][Mm]))$";
+
+/// Regex for matching a valid 24-hour time format (HH:MM).
+///
+/// Note this regex does not allow omitting the leading zeros.
+///
+/// ## Example
+///
+/// ```rust
+/// use regex::Regex;
+/// use valust_regex_utils::time::HH_MM_24H;
+///
+/// let time_regex = Regex::new(HH_MM_24H).unwrap();
+///
+/// assert!(time_regex.is_match("00:00"));
+/// assert!(time_regex.is_match("23:59"));
+/// assert!(!time_regex.is_match("24:00"));
+///
+/// assert!(time_regex.is_match("01:59"));
+/// assert!(!time_regex.is_match("1:60"));
+/// ```
+pub const HH_MM_24H: &str = r"^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$";
+
+/// Regex for matching a valid 24-hour time format (HH:MM).
+///
+/// Note this regex allows omitting the leading zeros.
+///
+/// ## Example
+///
+/// ```rust
+/// use regex::Regex;
+/// use valust_regex_utils::time::HH_MM_24H_NO_LEADING;
+///
+/// let time_regex = Regex::new(HH_MM_24H_NO_LEADING).unwrap();
+///
+/// assert!(time_regex.is_match("0:00"));
+/// assert!(time_regex.is_match("23:59"));
+/// assert!(!time_regex.is_match("24:00"));
+///
+/// assert!(time_regex.is_match("1:59"));
+/// assert!(!time_regex.is_match("1:60"));
+/// ```
+pub const HH_MM_24H_NO_LEADING: &str = r"^([0-9]|0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$";
+
+/// Regex for matching a valid 24-hour time format (HH:MM:SS).
+///
+/// Note this regex does not allow omitting the leading zeros.
+///
+/// ## Example
+///
+/// ```rust
+/// use regex::Regex;
+/// use valust_regex_utils::time::HH_MM_SS;
+///
+/// let time_regex = Regex::new(HH_MM_SS).unwrap();
+///
+/// assert!(time_regex.is_match("00:00:00"));
+/// assert!(time_regex.is_match("23:59:59"));
+/// assert!(!time_regex.is_match("24:00:00"));
+///
+/// assert!(time_regex.is_match("01:59:59"));
+/// assert!(!time_regex.is_match("1:60:00"));
+/// ```
+pub const HH_MM_SS: &str = r"^(?:[01]\d|2[0123]):(?:[012345]\d):(?:[012345]\d)$";


### PR DESCRIPTION
- Add utils for regex validation. This is planned to be directly included in the `valust-derive` crate.  
  Supported validator:
  - email
  - username
  - URL
  - hex color code
  - time (12h/24h)